### PR TITLE
Functions for getting/setting tank tickets and getting flow values for arbitrary positions.

### DIFF
--- a/gamedata/l4d2_direct.txt
+++ b/gamedata/l4d2_direct.txt
@@ -357,6 +357,20 @@
 				"windows"	"11260"
 				"linux"		"11244"
 			}
+			
+			"CTerrorPlayer::m_iTankTickets"
+			{
+				"windows"	"12424"
+				"linux"		"12408"
+			}
+			
+			/* TerrorNavArea Variable Offsets */
+			
+			"TerrorNavArea::m_flow"
+			{
+				"windows"	"332"
+				"linux"		"340"
+			}
 		}
 		
 		"Signatures"
@@ -390,6 +404,14 @@
 			{
 				"library"	"server"
 				"linux"		"@TheNavMesh"
+			}
+
+			"CNavMesh::GetNavArea"
+			{
+				"library"	"server"
+				"windows"	"\x83\xEC\x10\x56\x8B\xF1\x83\x7E\x2A\x2A\x75\x2A\x33\xC0\x5E\x83\xC4\x10\xC2\x08"
+				/* 83 EC 10 56 8B F1 83 7E ? ? 75 ? 33 C0 5E 83 C4 10 C2 08 */
+				"linux"		"@_ZNK8CNavMesh10GetNavAreaERK6Vectorf"
 			}
 		}
 		

--- a/gamedata/l4d2_direct.txt
+++ b/gamedata/l4d2_direct.txt
@@ -37,7 +37,7 @@
 			/* Virtual Table Offsets */
 			"CBaseEntity::GetBaseEntity"
 			{
-				"windows" 	"7"
+				"windows" 	"5"
 				"linux"		"6"
 			}
 

--- a/scripting/include/l4d2_direct.inc
+++ b/scripting/include/l4d2_direct.inc
@@ -387,6 +387,7 @@ stock Float:L4D2Direct_GetMapMaxFlowDistance()
  * Get a reference to a CountdownTimer that tracks when an SI player can next spawn.
  *
  * @note The duration of this timer is controlled by the cvars z_ghost_delay_min and z_ghost_delay_max.
+ * @param client		Client id to get the spawn timer for
  * @return				CountdownTimer reference to the timer, or CTimer_Null on lookup failure.
  * @error				Invalid client.
  */
@@ -404,5 +405,109 @@ stock CountdownTimer:L4D2Direct_GetSpawnTimer(client)
 		return CTimer_Null;
 
 	return CountdownTimer:(pEntity + Address:offs);
+}
+
+/**
+ * Looks up the number of tickets a client has for entry into the tank lottery.
+ *
+ * @note The number of tickets you have is equal to your damage done as an SI and will still increase as you do damage with the Tank.
+ * @note When the tank is passed away from you your tickets are set back to zero.
+ * @param client		Client id to get the tickets for
+ * @return				Number of tickets.
+ * @error				Invalid client.
+ */
+stock L4D2Direct_GetTankTickets(client)
+{
+	if (client < 1 || client > MaxClients)
+		return -1;
+
+	new Address:pEntity = GetEntityAddress(client);
+	if (pEntity == Address_Null)
+		return -1;
+
+	new offs = GameConfGetOffset(L4D2Direct_GetGameConf(), "CTerrorPlayer::m_iTankTickets");
+	if (offs == -1)
+		return -1;
+
+	return LoadFromAddress(pEntity + Address:offs, NumberType_Int32);
+}
+
+/**
+ * Sets the number of tickets a player has for entry into the tank lottery.
+ *
+ * @param client		Client id to set the tickets for
+ * @param tickets		New value for the client's tank lottery tickets
+ * @noreturn
+ * @error				Invalid client.
+ */
+stock L4D2Direct_SetTankTickets(client, tickets)
+{
+	if (client < 1 || client > MaxClients)
+		return -1;
+
+	new Address:pEntity = GetEntityAddress(client);
+	if (pEntity == Address_Null)
+		return -1;
+
+	new offs = GameConfGetOffset(L4D2Direct_GetGameConf(), "CTerrorPlayer::m_iTankTickets");
+	if (offs == -1)
+		return -1;
+
+	StoreToAddress(pEntity + Address:offs, tickets, NumberType_Int32);
+}
+
+/**
+ * Get the TerrorNavArea which holds a specific position.
+ *
+ * @note Some positions will not return a nav area (Address_Null). Notable examples are saferooms and small ledges like the guard rail at the start of c2m1_highway.
+ * @param pos           The position to find the containing nav area of
+ * @param beneathLimit
+ * @return              Address to a TerrorNavArea or Address_Null
+ * @error               Unable to prepare SDK call
+ */
+stock Address:L4D2Direct_GetTerrorNavArea(Float:pos[3], Float:beneathLimit = 120.0)
+{
+	static Handle:GetNavAreaSDKCall = INVALID_HANDLE;
+
+	if (GetNavAreaSDKCall == INVALID_HANDLE)
+	{
+		StartPrepSDKCall(SDKCall_Raw);
+		
+		if (!PrepSDKCall_SetFromConf(L4D2Direct_GetGameConf(), SDKConf_Signature, "CNavMesh::GetNavArea"))
+		{
+			return Address_Null;
+		}
+		
+		PrepSDKCall_AddParameter(SDKType_Vector, SDKPass_ByRef);
+		PrepSDKCall_AddParameter(SDKType_Float, SDKPass_Plain);
+		PrepSDKCall_SetReturnInfo(SDKType_PlainOldData, SDKPass_Plain);
+		GetNavAreaSDKCall = EndPrepSDKCall();
+		
+		if (GetNavAreaSDKCall == INVALID_HANDLE)
+		{
+			return Address_Null;
+		}
+	}
+	
+	return Address:SDKCall(GetNavAreaSDKCall, L4D2Direct_GetTerrorNavMesh(), pos, beneathLimit);
+}
+
+/**
+ * Find the distance through the map (in flow units) that a TerrorNavArea is located.
+  *
+ * @param  pTerrorNavArea   Pointer to a TerrorNavArea
+ * @return                  The flow units through the map that the TerrorNavArea is located at.
+ * @error                   When passed an Address_Null
+ */
+stock Float:L4D2Direct_GetTerrorNavAreaFlow(Address:pTerrorNavArea)
+{
+	if (pTerrorNavArea == Address_Null)
+		return 0.0;
+
+	new offs = GameConfGetOffset(L4D2Direct_GetGameConf(), "TerrorNavArea::m_flow");
+	if (offs == -1)
+		return 0.0;
+
+	return Float:LoadFromAddress(pTerrorNavArea + Address:offs, NumberType_Int32);
 }
 

--- a/scripting/l4d2direct_test.sp
+++ b/scripting/l4d2direct_test.sp
@@ -29,6 +29,38 @@ public OnPluginStart()
 	RegConsoleCmd("sm_settank", settank);
 	RegConsoleCmd("sm_myaddy", myaddy);
 	RegConsoleCmd("sm_myspawntimer", myspawntimer);
+	RegConsoleCmd("sm_mytickets", mytickets);
+	RegConsoleCmd("sm_myflow", myflow);
+}
+
+public Action:myflow(client, args)
+{
+	if (client == 0)
+	{
+		ReplyToCommand(client, "Not the server bro");
+		return;
+	}
+	
+	new Float:pos[3];
+	GetEntPropVector(client, Prop_Send, "m_vecOrigin", pos);
+	
+	new Address:pNavArea = L4D2Direct_GetTerrorNavArea(pos);
+	
+	if (pNavArea == Address_Null)
+	{
+		ReplyToCommand(client, "You're no where");
+		return;
+	}
+	
+	new Float:flow = L4D2Direct_GetTerrorNavAreaFlow(pNavArea);
+	new prcnt = RoundToNearest((flow / L4D2Direct_GetMapMaxFlowDistance()) * 100.0);
+	ReplyToCommand(client, "flow = %f (%d%%)", flow, prcnt);
+}
+
+public Action:mytickets(client, args)
+{
+	new tickets = L4D2Direct_GetTankTickets(client);
+	ReplyToCommand(client, "Your tank lottery tickets = %d", tickets);
 }
 
 public Action:myspawntimer(client,args)


### PR DESCRIPTION
The tank stuff can (hopefully) be used to force the director to pick a specific player as the tank. As it doesn't involve some of the hacky shit in other plugins I've seen it shouldn't result in the HUD notification being wrong or double passes.

Flow values stuff could be useful for reducing the size of mapinfo.txt maybe, but what I'm interested in doing with it is updating the item tracking plugin, i.e. increasing the frequency of pills spawns after the tank or after 50% of the map etc.
